### PR TITLE
harden API security headers - closes #23

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -48,6 +48,33 @@ const AUTH_POLICY: RateLimitPolicy = {
 const rateLimitBuckets = new Map<string, RateLimitBucket>();
 let lastCleanupAt = 0;
 
+const API_CONTENT_SECURITY_POLICY = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'"
+].join("; ");
+
+const API_PERMISSIONS_POLICY = [
+  "accelerometer=()",
+  "autoplay=()",
+  "camera=()",
+  "display-capture=()",
+  "encrypted-media=()",
+  "fullscreen=()",
+  "geolocation=()",
+  "gyroscope=()",
+  "magnetometer=()",
+  "microphone=()",
+  "midi=()",
+  "payment=()",
+  "picture-in-picture=()",
+  "publickey-credentials-get=()",
+  "screen-wake-lock=()",
+  "usb=()",
+  "xr-spatial-tracking=()"
+].join(", ");
+
 const isAuthPath = (pathname: string) => pathname.startsWith("/api/auth/");
 
 const getPolicy = (pathname: string) => (isAuthPath(pathname) ? AUTH_POLICY : GENERAL_POLICY);
@@ -89,6 +116,11 @@ const applyApiSecurityHeaders = (response: NextResponse) => {
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   response.headers.set("Referrer-Policy", "same-origin");
+  response.headers.set("Content-Security-Policy", API_CONTENT_SECURITY_POLICY);
+  response.headers.set("Permissions-Policy", API_PERMISSIONS_POLICY);
+  response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
+  response.headers.set("Cross-Origin-Resource-Policy", "same-origin");
+  response.headers.set("X-DNS-Prefetch-Control", "off");
 };
 
 const applyRateLimitHeaders = (


### PR DESCRIPTION
- Hardened API response security headers in `proxy.ts` to reduce browser-side attack surface.
- Added strict Content-Security-Policy for API responses (default-src 'none', base-uri 'none', frame-ancestors 'none', form-action 'self').
- Added restrictive Permissions-Policy disabling non-essential browser features for API calls.
- Added cross-origin hardening headers: Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy, and X-DNS-Prefetch-Control.
- Kept existing behavior intact (no API contract/functionality changes; rate limiting and existing headers remain).
- Validation: npm run lint passes.