### PR TITLE
add 2025 income in rrsp calc. to budget-state

### DIFF
--- a/components/BudgetApp.tsx
+++ b/components/BudgetApp.tsx
@@ -28,6 +28,7 @@ type Action =
   | { type: "set-yearly-salary"; amount: number }
   | { type: "set-bonus-type"; bonusType: BonusType }
   | { type: "set-bonus-value"; amount: number }
+  | { type: "set-rrsp-income-2025"; amount: number }
   | { type: "add-expense" }
   | { type: "remove-expense"; index: number }
   | { type: "set-expense-name"; index: number; name: string }
@@ -129,6 +130,11 @@ const reducer = (state: BudgetState, action: Action): BudgetState => {
             : state.bonusType === "percentage"
               ? normalizeMoney(action.amount, MAX_BONUS_PERCENT)
               : 0
+      };
+    case "set-rrsp-income-2025":
+      return {
+        ...state,
+        rrspIncome2025: normalizeMoney(action.amount, MAX_YEARLY_SALARY)
       };
     case "set-investment-frequency":
       return {
@@ -375,7 +381,6 @@ export default function BudgetApp({ username }: BudgetAppProps) {
   const [isIncomeHelpOpen, setIsIncomeHelpOpen] = useState(false);
   const [isExpenseChartOpen, setIsExpenseChartOpen] = useState(false);
   const [isInvestmentHelpOpen, setIsInvestmentHelpOpen] = useState(false);
-  const [rrspIncome2025, setRrspIncome2025] = useState(0);
   const [incomeViewMode, setIncomeViewMode] = useState<ViewMode>("list");
   const [expenseViewMode, setExpenseViewMode] = useState<ViewMode>("list");
   const [expenseSortOrder, setExpenseSortOrder] = useState<ExpenseSortOrder>("desc");
@@ -607,7 +612,7 @@ export default function BudgetApp({ username }: BudgetAppProps) {
       state.investments.rrsp,
       state.frequencies.investments.rrsp
     );
-    const rrspBasedOnIncome = rrspIncome2025 * 0.18;
+    const rrspBasedOnIncome = state.rrspIncome2025 * 0.18;
     const rrspLimit = Math.min(RRSP_2026_CAP, rrspBasedOnIncome);
 
     return {
@@ -645,7 +650,7 @@ export default function BudgetApp({ username }: BudgetAppProps) {
       }))
     };
   }, [
-    rrspIncome2025,
+    state.rrspIncome2025,
     state.frequencies.investments.fhsa,
     state.frequencies.investments.rrsp,
     state.frequencies.investments.tfsa,
@@ -1474,9 +1479,12 @@ export default function BudgetApp({ username }: BudgetAppProps) {
                     type="number"
                     min={0}
                     step={1}
-                    value={rrspIncome2025}
+                    value={state.rrspIncome2025}
                     onChange={(event) =>
-                      setRrspIncome2025(Math.max(0, toNumber(event.target.value)))
+                      safeDispatch({
+                        type: "set-rrsp-income-2025",
+                        amount: Math.max(0, toNumber(event.target.value))
+                      })
                     }
                     onFocus={selectInputValueOnFocus}
                     className="input tabular-nums pl-7 pr-3 text-right"

--- a/lib/budget-state.ts
+++ b/lib/budget-state.ts
@@ -11,6 +11,7 @@ export const DEFAULT_STATE: BudgetState = {
   yearlySalary: 0,
   bonusType: "none",
   bonusValue: 0,
+  rrspIncome2025: 0,
   expenses: [{ name: "Expense", amount: 0, frequency: "monthly" }],
   investments: {
     tfsa: 0,
@@ -124,6 +125,7 @@ export const sanitizeBudgetState = (input: unknown): BudgetState => {
     yearlySalary: normalizeAmount(candidate.yearlySalary, MAX_YEARLY_SALARY),
     bonusType,
     bonusValue: normalizeBonusValue(candidate.bonusValue, bonusType),
+    rrspIncome2025: normalizeAmount(candidate.rrspIncome2025, MAX_YEARLY_SALARY),
     expenses,
     investments: {
       tfsa: normalizeAmount(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,6 +27,7 @@ export type BudgetState = {
   yearlySalary: number;
   bonusType: BonusType;
   bonusValue: number;
+  rrspIncome2025: number;
   expenses: ExpenseItem[];
   investments: InvestmentState;
   frequencies: BudgetFrequencies;


### PR DESCRIPTION
- Added `rrspIncome2025` to `BudgetState` in `types.ts` (line 27).
- Added default + sanitization support in `budget-state.ts` (line 11) and `budget-state.ts` (line 125).
- Updated `BudgetApp` to store this value in reducer state (not local `useState`) and dispatch through `safeDispatch` in `BudgetApp.tsx` (line 28), BudgetApp.tsx` (line 131), and `BudgetApp.tsx` (line 1479).